### PR TITLE
Fix smart formatting issue

### DIFF
--- a/src/test.ts
+++ b/src/test.ts
@@ -63,6 +63,7 @@ const main = async () => {
     language: "en-US",
     tier: "nova",
     model: "phonecall",
+    no_delay: true
   });
 
   transcriber.addListener("close", () => {


### PR DESCRIPTION
When using Smart Formatting the default behavior is to wait for more numbers if there is a pause after a number.

This can be disabled using `no_delay=true`